### PR TITLE
请升级org.hibernate:hibernate-core组件版本以解决2个安全漏洞

### DIFF
--- a/documentation/src/main/asciidoc/quickstart/tutorials/entitymanager/pom.xml
+++ b/documentation/src/main/asciidoc/quickstart/tutorials/entitymanager/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
-            <version>$version</version>
+            <version>5.4.24.Final</version>
         </dependency>
     </dependencies>
 

--- a/documentation/src/main/asciidoc/quickstart/tutorials/pom.xml
+++ b/documentation/src/main/asciidoc/quickstart/tutorials/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
-            <version>$version</version>
+            <version>5.4.24.Final</version>
         </dependency>
 
         <!-- Hibernate uses jboss-logging for logging, for the tutorials we will use the sl4fj-simple backend -->


### PR DESCRIPTION
将 **org.hibernate:hibernate-core** 组件从$version 版本升级至 5.4.24.Final版本,
用于修复以下安全漏洞：


序号 | 漏洞编号 | 漏洞标题 | 漏洞级别
-- | -- | -- | --
1 | [MPS-2020-9908](https://www.oscs1024.com/hd/MPS-2020-9908) | Hibernate 存在 SQL 注入漏洞 | 中危
2 | [MPS-2020-16768](https://www.oscs1024.com/hd/MPS-2020-16768) | hibernate-core <5.4.24.Final 存在 SQL 注入漏洞 | 高危
  |   |   |   


<br/>

_注意 ：此 PR 由您（或拥有此仓库权限的其他维护者）授权 [墨菲安全](https://www.murphysec.com) 打开_

了解更多：
- [如何快速修复代码安全问题](https://www.murphysec.com/docs/faqs/security-issues/how-to-quick-fixes.html)
